### PR TITLE
Exibir cinco salas por linha em várias resoluções

### DIFF
--- a/front/rei-rosa/src/components/Room/Button/styles.js
+++ b/front/rei-rosa/src/components/Room/Button/styles.js
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 
 export const Container = styled.button`
-  border:solid 2px #e2e6ed;
+  border:solid 4px #e2e6ed;
   height:120px;
-  width:170px;
-  margin: 15px 20px;
+  width:15%;
+  margin: 1% 2%;
   align-items: center;
   color:#ecf1f8;
   background:#ecf1f8;

--- a/front/rei-rosa/src/components/Room/styles.js
+++ b/front/rei-rosa/src/components/Room/styles.js
@@ -6,5 +6,6 @@ export const Container = styled.div`
   display: flex;
   flex-wrap:wrap;
   flex-direction: row;
-  justify-content: space-between;
+  align-items: center;
+  justify-content: center;
 `;


### PR DESCRIPTION
### Escopo
Fazer a tela inicial apresentar duas linhas de cinco salas independente da resolução do monitor do client.

### Plano de Testes
- Iniciar a aplicação;
- Dar zoom na página (Ctrl + Scroll para cima ou para baixo);
##### Critérios de Aceitação
- Sempre devem ser apresentadas duas linhas com cinco salas, independente do(a) zoom/resolução.