### PR TITLE
Endpoint para buscar todas as salas sincronizadas

### DIFF
--- a/back/rei-rosa/src/models/enums/room-sticker-geo-form.js
+++ b/back/rei-rosa/src/models/enums/room-sticker-geo-form.js
@@ -1,1 +1,1 @@
-module.exports = ["TRIANGLE", "SQUARE"];
+module.exports = ["CIRCLE", "SQUARE"];

--- a/back/rei-rosa/src/server.js
+++ b/back/rei-rosa/src/server.js
@@ -91,7 +91,7 @@ app.get('/sync/rooms', (req, res) => {
             return multi.execAsync();
         })
         .then(rooms => {
-            res.send({ synchronized: true, rooms: JSON.parse(rooms[0]) });
+            res.send({ synchronized: true, rooms: rooms.map(room => JSON.parse(room)) });
         })
         .catch(error => {
             console.error(error);


### PR DESCRIPTION
### Escopo
Criar um endpoint que retorne todas as salas sincronizadas para que o mobile possa consumir.

### Plano de Testes
- Subir a aplicação;
- Em um novo terminal, acessar a `memurai-cli`;
- Executar o comando `get SYNC`;
- Executar uma requisição GET via Postman para `localhost:3001/sync/rooms`;
- Executar uma requisição GET via Postman para `localhost:3001/room/[ALGUM NÚMERO X]`;
- Executar uma requisição POST via Postman para `localhost:3001/sync`;
- Executar uma requisição GET via Postman para `localhost:3001/sync/rooms`;
##### Critérios de Aceitação
- O valor retornado pelo comando executado no terceiro passo do Plano de Testes deve ser `false`.
- O valor retornado pela requisição executada no quarto passo do Plano de Testes deve ser `{ "synchronized" : false }`.
- O valor retornado pela requisição executada no último passo do Plano de Testes deve ser
 `{ "synchronized" : true, "rooms" : [ ] }`, em que o valor de `rooms` é um array contendo X (o número informado no quinto passo do Plano de Testes) salas.